### PR TITLE
Use non-Admin API to query VMs wherever possible

### DIFF
--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -145,7 +145,7 @@ class VDC(object):
             self.href = self.resource.get('href')
 
     def query_vm_by_name(self, name):
-        """Query a VM by name.
+        """Query a VM by name using Admin API.
 
         :param str name: name of the VM.
 
@@ -160,7 +160,7 @@ class VDC(object):
         vdc_filter = ('vdc==%s' % urllib.parse.quote(self.href))
         name_filter = ('name', name)
         query_obj = self.client.get_typed_query(
-            ResourceType.ADMIN_VM.value,
+            ResourceType.VM.value,
             qfilter=vdc_filter,
             equality_filter=name_filter)
         vm_href = query_obj.find_unique().get('href')


### PR DESCRIPTION
If possible do not use the Admin API:

- In the `query_vm_by_name` method use the non-Admin API
- I was tempted just to create a new method called `query_vm_by_name_not_as_admin` but decided that wasn't necessary: I think this fine, both the Admin and non-Admin query return an XML object with a 'href' which is what we care about: 

As per https://www.vmware.com/support/vcd/doc/rest-api-doc-1.5-html/types/QueryResultVMRecordType.html and https://www.vmware.com/support/vcd/doc/rest-api-doc-1.5-html/types/QueryResultAdminVMRecordType.html both return something with a href 

[@shasimm22](https://github.com/shashim22) added this method last summer in https://github.com/vmware/pyvcloud/pull/367/files so should definitely review, :-) 